### PR TITLE
Added test to cover 100% + fixed fatal error

### DIFF
--- a/src/Stringy/Stringy.php
+++ b/src/Stringy/Stringy.php
@@ -359,7 +359,7 @@ class Stringy
     public function pad($length, $padStr = ' ', $padType = 'right')
     {
         if (!in_array($padType, array('left', 'right', 'both'))) {
-            throw new InvalidArgumentException('Pad expects $padType ' .
+            throw new \InvalidArgumentException('Pad expects $padType ' .
                 "to be one of 'left', 'right' or 'both'");
         }
 

--- a/tests/Stringy/StaticStringyTest.php
+++ b/tests/Stringy/StaticStringyTest.php
@@ -140,6 +140,14 @@ class StaticStringyTestCase extends CommonTest
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPadException()
+    {
+        $result = S::pad('string', 5, 'foo', 'bar');
+    }
+
+    /**
      * @dataProvider stringsForPadLeft
      */
     public function testPadLeft($expected, $str, $length, $padStr = ' ',

--- a/tests/Stringy/StringyTest.php
+++ b/tests/Stringy/StringyTest.php
@@ -188,6 +188,15 @@ class StringyTestCase extends CommonTest
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPadException()
+    {
+        $stringy = S::create('foo');
+        $result = $stringy->pad(5, 'foo', 'bar');
+    }
+
+    /**
      * @dataProvider stringsForPadLeft
      */
     public function testPadLeft($expected, $str, $length, $padStr = ' ',


### PR DESCRIPTION
Found bug this while adding a test to cover 100% of the codebase.

Otherwise a fatal error will get thrown by PHP. (Class `Stringy\InvalidArgumentException` not found)

Cheers,

Chris
