### PR TITLE
changes in create function

### DIFF
--- a/src/Stringy/Stringy.php
+++ b/src/Stringy/Stringy.php
@@ -33,7 +33,7 @@ class Stringy
      */
     public static function create($str, $encoding = null)
     {
-        return new self($str, $encoding);
+        return new static($str, $encoding);
     }
 
     /**


### PR DESCRIPTION
Hi

I'm using Stringy and need to extend class, but for now static function 'create' uses 'new self' and i can't extend Stringy without copy create function to child class. For this I've changed to 'new static'.

As i see in composer.json min php version is 5.3 so all will be fine.
http://php.net/manual/en/language.oop5.late-static-bindings.php
