### PR TITLE
Adding optional $replacement parameter to slugify.

### DIFF
--- a/src/Stringy/StaticStringy.php
+++ b/src/Stringy/StaticStringy.php
@@ -326,14 +326,16 @@ class StaticStringy
      * Converts the string into an URL slug. This includes replacing non-ASCII
      * characters with their closest ASCII equivalents, removing non-alphanumeric
      * and non-ASCII characters, and replacing whitespace with dashes. The string
-     * is also converted to lowercase.
+     * is also converted to lowercase. If defined, whitespace is replaced with
+     * $replacement instead of dashes.
      *
-     * @param   string  $str  Text to transform into an URL slug
+     * @param   string  $str          Text to transform into an URL slug
+     * @param   string  $replacement  The string to replace whitespace with
      * @return  string  The corresponding URL slug
      */
-    public static function slugify($str)
+    public static function slugify($str, $replacement = '-')
     {
-        return Stringy::create($str)->slugify()->str;
+        return Stringy::create($str)->slugify($replacement)->str;
     }
 
     /**

--- a/src/Stringy/Stringy.php
+++ b/src/Stringy/Stringy.php
@@ -578,17 +578,19 @@ class Stringy
      * Converts the string into an URL slug. This includes replacing non-ASCII
      * characters with their closest ASCII equivalents, removing non-alphanumeric
      * and non-ASCII characters, and replacing whitespace with dashes. The string
-     * is also converted to lowercase.
+     * is also converted to lowercase. If defined, whitespace is replaced with
+     * $replacement instead of dashes.
      *
+     * @param   string   $replacement  The string to replace whitespace with
      * @return  Stringy  Object whose $str has been converted to an URL slug
      */
-    public function slugify()
+    public function slugify($replacement = '-')
     {
         $stringy = self::create($this->str, $this->encoding);
 
-        $stringy->str = preg_replace('/[^a-zA-Z\d -]/u', '', $stringy->toAscii());
+        $stringy->str = preg_replace("/[^a-zA-Z\d $replacement]/u", '', $stringy->toAscii());
         $stringy->str = $stringy->collapseWhitespace()->str;
-        $stringy->str = str_replace(' ', '-', strtolower($stringy->str));
+        $stringy->str = str_replace(' ', $replacement, strtolower($stringy->str));
 
         return $stringy;
     }

--- a/tests/Stringy/CommonTest.php
+++ b/tests/Stringy/CommonTest.php
@@ -330,7 +330,9 @@ abstract class CommonTest extends PHPUnit_Framework_TestCase
             array('unrecognized-chars-like', 'unrecognized chars like συγγρ'),
             array('numbers-1234', 'numbers 1234'),
             array('perevirka-ryadka', 'перевірка рядка'),
-            array('bukvar-s-bukvoy-y', 'букварь с буквой ы')
+            array('bukvar-s-bukvoy-y', 'букварь с буквой ы'),
+            array('foo:bar:baz', 'Foo bar baz', ':'),
+            array('a_string_with_underscores', 'A_string with_underscores', '_')
         );
     }
 

--- a/tests/Stringy/StaticStringyTest.php
+++ b/tests/Stringy/StaticStringyTest.php
@@ -245,9 +245,9 @@ class StaticStringyTestCase extends CommonTest
     /**
      * @dataProvider slugifyProvider()
      */
-    public function testSlugify($expected, $str)
+    public function testSlugify($expected, $str, $replacement = '-')
     {
-        $result = S::slugify($str);
+        $result = S::slugify($str, $replacement);
         $this->assertInternalType('string', $result);
         $this->assertEquals($expected, $result);
     }

--- a/tests/Stringy/StringyTest.php
+++ b/tests/Stringy/StringyTest.php
@@ -312,10 +312,10 @@ class StringyTestCase extends CommonTest
     /**
      * @dataProvider slugifyProvider()
      */
-    public function testSlugify($expected, $str)
+    public function testSlugify($expected, $str, $replacement = '-')
     {
         $stringy = S::create($str);
-        $result = $stringy->slugify();
+        $result = $stringy->slugify($replacement);
         $this->assertInstanceOf('Stringy\Stringy', $result);
         $this->assertEquals($expected, $result);
         $this->assertEquals($str, $stringy);


### PR DESCRIPTION
Thanks for this excellent library. I've added an optional $replacement parameter so the slug can be padded with different characters.

I updated the tests and comments, but have left the README - I figured you'd want to do this as per pull request #3. I'd be happy to update it myself too.

Thanks!
