### PR TITLE
type cast in removeLeft && removeRight

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -637,7 +637,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
             $startOfStr = mb_strtolower($startOfStr, $this->encoding);
         }
 
-        return $substring === $startOfStr;
+        return (string) $substring === $startOfStr;
     }
 
     /**
@@ -662,7 +662,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
             $endOfStr = mb_strtolower($endOfStr, $this->encoding);
         }
 
-        return $substring === $endOfStr;
+        return (string) $substring === $endOfStr;
     }
 
     /**

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Stringy\Stringy;
+
 abstract class CommonTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -752,6 +754,8 @@ abstract class CommonTest extends PHPUnit_Framework_TestCase
             array('bar', 'foo bar', 'foo '),
             array('foo bar', 'foo bar', 'oo'),
             array('foo bar', 'foo bar', 'oo bar'),
+            array('oo bar', 'foo bar', Stringy::create('foo bar')->first(1), 'UTF-8'),
+            array('oo bar', 'foo bar', Stringy::create('foo bar')->at(0), 'UTF-8'),
             array('fòô bàř', 'fòô bàř', '', 'UTF-8'),
             array('òô bàř', 'fòô bàř', 'f', 'UTF-8'),
             array('bàř', 'fòô bàř', 'fòô ', 'UTF-8'),
@@ -768,6 +772,8 @@ abstract class CommonTest extends PHPUnit_Framework_TestCase
             array('foo', 'foo bar', ' bar'),
             array('foo bar', 'foo bar', 'ba'),
             array('foo bar', 'foo bar', 'foo ba'),
+            array('foo ba', 'foo bar', Stringy::create('foo bar')->last(1), 'UTF-8'),
+            array('foo ba', 'foo bar', Stringy::create('foo bar')->at(6), 'UTF-8'),
             array('fòô bàř', 'fòô bàř', '', 'UTF-8'),
             array('fòô bà', 'fòô bàř', 'ř', 'UTF-8'),
             array('fòô', 'fòô bàř', ' bàř', 'UTF-8'),


### PR DESCRIPTION
I don't even know if it is unexpected behavior or not, but when I write
```
$string->removeLeft($string->first(1))->removeRight($string->last(1))
```
I expect that first and last characters of string are removed.

Also I want to add more shortcuts and some functional to Stringy, what do you think about it?

* removeFirst
* removeLast

* extractDigits
* extractLetters

* ...

It's super easy to implement, and they can save some time for users of package.

@danielstjules Do Stringy needs this functional, what do you think ?
Thank you for your time!