### PR TITLE
Proper Stringy\create() description

### DIFF
--- a/src/Create.php
+++ b/src/Create.php
@@ -3,7 +3,7 @@
 namespace Stringy;
 
 /**
- * Invokes Stringy::create and returns the generated Stringy object on success.
+ * Creates a Stringy object and returns it on success.
  *
  * @param  mixed   $str      Value to modify, after being cast to string
  * @param  string  $encoding The character encoding


### PR DESCRIPTION
The code could have been changed to `return Stringy::create($str, $encoding);`, but it wouldn't bring any benefit (still hardcoded class).