### PR TITLE
Remove some useless (and erroneous) regex capturing groups

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1247,7 +1247,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function isAlpha()
     {
-        return $this->matchesPattern('^([[:alpha:]])*$');
+        return $this->matchesPattern('^[[:alpha:]]*$');
     }
 
     /**
@@ -1258,7 +1258,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function isAlphanumeric()
     {
-        return $this->matchesPattern('^([[:alnum:]])*$');
+        return $this->matchesPattern('^[[:alnum:]]*$');
     }
 
     /**
@@ -1269,7 +1269,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function isHexadecimal()
     {
-        return $this->matchesPattern('^([[:xdigit:]])*$');
+        return $this->matchesPattern('^[[:xdigit:]]*$');
     }
 
     /**
@@ -1280,7 +1280,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function isBlank()
     {
-        return $this->matchesPattern('^([[:space:]])*$');
+        return $this->matchesPattern('^[[:space:]]*$');
     }
 
     /**
@@ -1303,7 +1303,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function isLowerCase()
     {
-        return $this->matchesPattern('^([[:lower:]])*$');
+        return $this->matchesPattern('^[[:lower:]]*$');
     }
 
     /**
@@ -1314,7 +1314,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      */
     public function isUpperCase()
     {
-        return $this->matchesPattern('^([[:upper:]])*$');
+        return $this->matchesPattern('^[[:upper:]]*$');
     }
 
     /**


### PR DESCRIPTION
The error is that the capturing group themselves were repeated. ([thorough description](http://www.regular-expressions.info/captureall.html))