### PR TITLE
Enabling dependency injection by adding a set method

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -20,11 +20,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
     protected $encoding;
 
     /**
-     * Initializes a Stringy object and assigns both str and encoding properties
-     * the supplied values. $str is cast to a string prior to assignment, and if
-     * $encoding is not specified, it defaults to mb_internal_encoding(). Throws
-     * an InvalidArgumentException if the first argument is an array or object
-     * without a __toString method.
+     * Initializes a Stringy object.
      *
      * @param  mixed  $str      Value to modify, after being cast to string
      * @param  string $encoding The character encoding
@@ -32,6 +28,25 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      *         __toString method is passed as the first argument
      */
     public function __construct($str, $encoding = null)
+    {
+        $this->set($str, $encoding);
+    }
+
+
+    /**
+     * Initializes a Stringy object and assigns both str and encoding properties
+     * the supplied values. This method also makes it possible to change the
+     * internal string without creating a new object. $str is cast to a string
+     * prior to assignment, and if $encoding is not specified, it defaults to
+     * mb_internal_encoding(). Throws an InvalidArgumentException if the first
+     * argument is an array or object without a __toString method.
+     *
+     * @param  mixed  $str      Value to modify, after being cast to string
+     * @param  string $encoding The character encoding
+     * @throws \InvalidArgumentException if an array or object without a
+     *         __toString method is passed as the first argument
+     */
+    public function set($str, $encoding = null)
     {
         if (is_array($str)) {
             throw new \InvalidArgumentException(

--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -60,6 +60,7 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
 
         $this->str = (string) $str;
         $this->encoding = $encoding ?: mb_internal_encoding();
+        return $this;
     }
 
     /**

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -916,8 +916,10 @@ class StringyTestCase extends CommonTest
 
     public function testSet()
     {
-        $stringy = S::create('lorem');
-        $stringy->set('ipsum');
-        $this->assertSame('ipsum', (string) $stringy);
+        $stringy1 = S::create('lorem');
+        $stringy2 = $stringy1->set('ipsum');
+        $this->assertSame('ipsum', (string) $stringy1);
+        $this->assertSame($stringy1, $stringy2);
+        $this->assertSame($stringy1->count(), $stringy1->set('ipsum')->count());
     }
 }

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -911,4 +911,13 @@ class StringyTestCase extends CommonTest
         $this->assertEquals($expected, $result);
         $this->assertEquals($str, $stringy);
     }
+
+
+
+    public function testSet()
+    {
+        $stringy = S::create('lorem');
+        $stringy->set('ipsum');
+        $this->assertSame('ipsum', (string) $stringy);
+    }
 }


### PR DESCRIPTION
By being able to change the internal string of the Stringy object it's possible to use it like a string manipulation factory/service. 

Example:

    class MyClass
    {
        public function __construct(Stringy $str) {
            $this->manipulated_class_name = $str->set(__CLASS__)->toLowerCase();
        }
    }

    new MyClass(Stringy::create(''));

