### PR TITLE
Adding the option to trim the string with others characters, and define which trim function to use

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1036,9 +1036,26 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
      * @param string $charList list with characters to be removed
      * @param int $type which function will be used to trim the string, trim, ltrim or rtrim
      * @return Stringy Object with a trimmed $str
+     * @throws \InvalidArgumentException
      */
     public function trim($charList = " \t\n\r\0\x0B", $type = self::TRIM_BOTH)
     {
+        if (!is_string($charList)) {
+            throw new \InvalidArgumentException(
+                'Charset list must be a string'
+            );
+        }
+
+        if (!in_array($type, array(
+            self::TRIM_BOTH,
+            self::TRIM_LEFT,
+            self::TRIM_RIGHT,
+        ))) {
+            throw new \InvalidArgumentException(
+                'Type of trim function must be trim (default), rtrim or ltrim, just as native php.'
+            );
+        }
+
         return static::create($type($this->str, $charList), $this->encoding);
     }
 

--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -4,6 +4,13 @@ namespace Stringy;
 
 class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
 {
+
+    const TRIM_BOTH = 'trim';
+
+    const TRIM_LEFT = 'ltrim';
+
+    const TRIM_RIGHT = 'rtrim';
+
     /**
      * An instance's string.
      *
@@ -1026,11 +1033,13 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
     /**
      * Returns the trimmed string. An alias for PHP's trim() function.
      *
+     * @param string $charList list with characters to be removed
+     * @param int $type which function will be used to trim the string, trim, ltrim or rtrim
      * @return Stringy Object with a trimmed $str
      */
-    public function trim()
+    public function trim($charList = " \t\n\r\0\x0B", $type = self::TRIM_BOTH)
     {
-        return static::create(trim($this->str), $this->encoding);
+        return static::create($type($this->str, $charList), $this->encoding);
     }
 
     /**

--- a/tests/CommonTest.php
+++ b/tests/CommonTest.php
@@ -590,7 +590,7 @@ abstract class CommonTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function trimProvider()
+    public function trimProviderWithoutParams()
     {
         return array(
             array('foo   bar', '  foo   bar  '),
@@ -601,6 +601,23 @@ abstract class CommonTest extends PHPUnit_Framework_TestCase
             array('fòô bàř', ' fòô bàř'),
             array('fòô bàř', 'fòô bàř '),
             array('fòô bàř', "\n\t fòô bàř \n\t")
+        );
+    }
+
+    public function trimProviderWithParams()
+    {
+        return array(
+            array('foo   bar', '  foo   bar  ', " \t\n\r\0\x0B", 'trim'),
+            array('foo bar', ' foo bar', " \t\n\r\0\x0B", 'trim'),
+            array('foo bar', 'foo bar ', " \t\n\r\0\x0B", 'trim'),
+            array('foo bar', "\n\t foo bar \n\t", " \t\n\r\0\x0B", 'trim'),
+            array('fòô   bàř', '  fòô   bàř  ', " \t\n\r\0\x0B", 'trim'),
+            array('fòô bàř', ' fòô bàř', " \t\n\r\0\x0B", 'trim'),
+            array('fòô bàř', 'fòô bàř ', " \t\n\r\0\x0B", 'trim'),
+            array('fòô bàř', "\n\t fòô bàř \n\t", " \t\n\r\0\x0B", 'trim'),
+            array('  foo   bar', '  foo   bar  ', " \t\n\r\0\x0B", 'rtrim'),
+            array('foo   bar  ', '  foo   bar  ', " \t\n\r\0\x0B", 'ltrim'),
+            array('  foo   bar  ', '  foo   bar  ', "\t\n\r\0\x0B", 'ltrim')
         );
     }
 

--- a/tests/StaticStringyTest.php
+++ b/tests/StaticStringyTest.php
@@ -382,7 +382,7 @@ class StaticStringyTestCase extends CommonTest
     }
 
     /**
-     * @dataProvider trimProvider()
+     * @dataProvider trimProviderWithoutParams()
      */
     public function testTrim($expected, $str)
     {

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -594,15 +594,49 @@ class StringyTestCase extends CommonTest
     }
 
     /**
-     * @dataProvider trimProvider()
+     * @dataProvider trimProviderWithoutParams()
      */
-    public function testTrim($expected, $str)
+    public function testTrimWithoutParams($expected, $str)
     {
         $stringy = S::create($str);
         $result = $stringy->trim();
         $this->assertStringy($result);
         $this->assertEquals($expected, $result);
         $this->assertEquals($str, $stringy);
+    }
+
+    /**
+     * @dataProvider trimProviderWithParams()
+     */
+    public function testTrimWithParams($expected, $str, $charList, $type)
+    {
+        $stringy = S::create($str);
+        $result = $stringy->trim($charList, $type);
+        $this->assertStringy($result);
+        $this->assertEquals($expected, $result);
+        $this->assertEquals($str, $stringy);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testTrimWithInvalidCharset()
+    {
+        $stringy = S::create('test');
+        $stringy->trim(array('test1', 'test2'), 'trim');
+        $this->fail('Expecting exception when the first argument passed is not a string');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testTrimWithInvalidType()
+    {
+        $stringy = S::create('test');
+        $stringy->trim(' test ', 'aa');
+        $stringy->trim('btest ', 'Trim');
+        $stringy->trim(' btest', 'RTrim');
+        $this->fail('Expecting exception when the first argument passed is not a string');
     }
 
     /**


### PR DESCRIPTION
Adding the option to trim the string with others characters, not only with the default characters provided by php. Also added the option to define the function which will be used to trim the string, if it's normal trim, left trim or right trim