### PR TITLE
Added isBase64 method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ s('string')->toTitleCase()->ensureRight('y') == 'Stringy'
     * [insert](#insertint-index-string-substring)
     * [isAlpha](#isalpha)
     * [isAlphanumeric](#isalphanumeric)
+    * [isBase64](#isbase64)
     * [isBlank](#isblank)
     * [isHexadecimal](#ishexadecimal)
     * [isJson](#isjson)
@@ -507,6 +508,15 @@ otherwise.
 
 ```php
 s('دانيال1')->isAlphanumeric(); // true
+```
+
+##### isBase64()
+
+Returns true if the string is base64 encoded, false
+otherwise.
+
+```php
+s('Zm9vYmFy')->isBase64(); // true
 ```
 
 ##### isBlank()

--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -627,6 +627,17 @@ class Stringy implements \Countable, \IteratorAggregate, \ArrayAccess
         return $this->str === 'b:0;' || @unserialize($this->str) !== false;
     }
 
+
+    /**
+     * Returns true if the string is base64 encoded, false otherwise.
+     *
+     * @return bool Whether or not $str is base64 encoded
+     */
+    public function isBase64()
+    {
+        return $this->str !== '' && ( base64_encode( base64_decode( $this->str, true ) ) === $this->str );
+    }
+
     /**
      * Returns true if the string contains only lower case chars, false
      * otherwise.

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -2171,6 +2171,31 @@ class StringyTestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider isBase64Provider()
+     */
+    public function testIsBase64($expected, $str)
+    {
+        $stringy = S::create($str);
+        $result = $stringy->isBase64();
+        $this->assertInternalType('boolean', $result);
+        $this->assertEquals($expected, $result);
+        $this->assertEquals($str, $stringy);
+    }
+
+    public function isBase64Provider()
+    {
+        return array(
+            array(false, ' '),
+            array(false, ''),
+            array(true, base64_encode('FooBar') ),
+            array(true, base64_encode(' ') ),
+            array(true, base64_encode('FÒÔBÀŘ') ),
+            array(true, base64_encode('συγγραφέας') ),
+            array(false, 'Foobar'),
+        );
+    }
+
+    /**
      * @dataProvider isUpperCaseProvider()
      */
     public function testIsUpperCase($expected, $str, $encoding = null)


### PR DESCRIPTION
I added support for a `isBase64` method to find out if a string is base64 encoded or not.