### PR TITLE
::$methodArgs is dynamically generated.

### DIFF
--- a/src/StaticStringy.php
+++ b/src/StaticStringy.php
@@ -11,85 +11,7 @@ class StaticStringy
      *
      * @var string[]
      */
-    protected static $methodArgs = array(
-        'append'                 => 3,
-        'at'                     => 3,
-        'between'                => 5,
-        'camelize'               => 2,
-        'chars'                  => 2,
-        'collapseWhitespace'     => 2,
-        'contains'               => 4,
-        'containsAll'            => 4,
-        'containsAny'            => 4,
-        'count'                  => 2,
-        'countSubstr'            => 4,
-        'dasherize'              => 2,
-        'delimit'                => 3,
-        'endsWith'               => 4,
-        'ensureLeft'             => 3,
-        'ensureRight'            => 3,
-        'first'                  => 3,
-        'getEncoding'            => 2,
-        'hasLowerCase'           => 2,
-        'hasUpperCase'           => 2,
-        'htmlDecode'             => 3,
-        'htmlEncode'             => 3,
-        'humanize'               => 2,
-        'indexOf'                => 4,
-        'indexOfLast'            => 4,
-        'insert'                 => 4,
-        'isAlpha'                => 2,
-        'isAlphanumeric'         => 2,
-        'isBlank'                => 2,
-        'isHexadecimal'          => 2,
-        'isJson'                 => 2,
-        'isLowerCase'            => 2,
-        'isSerialized'           => 2,
-        'isUpperCase'            => 2,
-        'last'                   => 3,
-        'length'                 => 2,
-        'lines'                  => 2,
-        'longestCommonPrefix'    => 3,
-        'longestCommonSuffix'    => 3,
-        'longestCommonSubstring' => 3,
-        'lowerCaseFirst'         => 2,
-        'pad'                    => 5,
-        'padBoth'                => 4,
-        'padLeft'                => 4,
-        'padRight'               => 4,
-        'prepend'                => 3,
-        'regexReplace'           => 5,
-        'removeLeft'             => 3,
-        'removeRight'            => 3,
-        'repeat'                 => 3,
-        'replace'                => 4,
-        'reverse'                => 2,
-        'safeTruncate'           => 4,
-        'shuffle'                => 2,
-        'slugify'                => 3,
-        'startsWith'             => 4,
-        'slice'                  => 4,
-        'split'                  => 4,
-        'substr'                 => 4,
-        'surround'               => 3,
-        'swapCase'               => 2,
-        'tidy'                   => 2,
-        'titleize'               => 3,
-        'toAscii'                => 3,
-        'toBoolean'              => 2,
-        'toLowerCase'            => 2,
-        'toSpaces'               => 3,
-        'toTabs'                 => 3,
-        'toTitleCase'            => 2,
-        'toUpperCase'            => 2,
-        'trim'                   => 3,
-        'trimLeft'               => 3,
-        'trimRight'              => 3,
-        'truncate'               => 4,
-        'underscored'            => 2,
-        'upperCamelize'          => 2,
-        'upperCaseFirst'         => 2
-    );
+    protected static $methodArgs = null;
 
     /**
      * Creates an instance of Stringy and invokes the given method with the
@@ -102,9 +24,20 @@ class StaticStringy
      *
      * @param string  $name
      * @param mixed[] $arguments
+     *
+     * @return Stringy
      */
     public static function __callStatic($name, $arguments)
     {
+        if (!static::$methodArgs) {
+            $methods = (new \ReflectionClass('Stringy\Stringy'))->getMethods(\ReflectionMethod::IS_PUBLIC);
+
+            foreach ($methods as $method) {
+                /** @var \ReflectionMethod $method */
+                static::$methodArgs[$method->name] = $method->getNumberOfParameters() + 2;
+            }
+        }
+
         if (!isset(static::$methodArgs[$name])) {
             throw new \BadMethodCallException($name . ' is not a valid method');
         }


### PR DESCRIPTION
Instead of manually defining each of the method args that can be made static, use a simple subroutine to update the arguments array on first run of the class.