### PR TITLE
Add codecov code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
     - php: 7.0
       env: polyfill='false'
 
+before_install:
+  - pip install --user codecov
+
 install: travis_retry composer install --no-interaction --prefer-source
 
 before_script:
@@ -39,5 +42,7 @@ before_script:
   - if [[ $polyfill = 'false' ]]; then travis_retry composer remove symfony/polyfill-mbstring; fi
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.xml
 
+after_success:
+  - codecov


### PR DESCRIPTION
A free account for public repos can be created at : https://codecov.io
The badge can be added on the readme.
The Chrome extension integrates well too: https://chrome.google.com/webstore/detail/codecov-extension/keefkhehidemnokodkdkejapdgfjmijf

---

Note: the automatic comment should probably be disabled, because it's sometimes quite anoying