### PR TITLE
Real strings from StaticStringy

### DIFF
--- a/src/StaticStringy.php
+++ b/src/StaticStringy.php
@@ -143,6 +143,12 @@ class StaticStringy
 
         $stringy = Stringy::create($str, $encoding);
 
-        return call_user_func_array(array($stringy, $name), $args);
+        $result = call_user_func_array(array($stringy, $name), $args);
+
+        if (is_object($result) && $result instanceof Stringy) {
+            $result = (string) $result;
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
I think that it's good to produce real strings from `StaticStringy`, not `Stringy` object that can be casted to a string.

Example situation: I do some manipulation with a string with `StaticStringy`, then assign the result to `base_uri` option of Guzzle client. After that I get "URI must be a string or UriInterface" error.

With PHP 7 it's even more important, because of scalar type hinting.
