### PR TITLE
Add method to capitalize person names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ s('string')->toTitleCase()->ensureRight('y') == 'Stringy'
     * [at](#atint-index)
     * [between](#betweenstring-start-string-end--int-offset)
     * [camelize](#camelize)
+    * [capitalizePersonName](#capitalizePersonName)
     * [chars](#chars)
     * [collapseWhitespace](#collapsewhitespace)
     * [contains](#containsstring-needle--boolean-casesensitive--true-)
@@ -300,6 +301,15 @@ and removes spaces, dashes, as well as underscores.
 
 ```php
 s('Camel-Case')->camelize(); // 'camelCase'
+```
+
+##### capitalizePersonName()
+
+Returns the string with the first letter of each word capitalized,
+except for when the word is a name which shouldn't be capitalized.
+
+```php
+s('jaap de hoop scheffer')->capitalizePersonName(); // 'Jaap de Hoop Scheffer'
 ```
 
 ##### chars()

--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1599,6 +1599,109 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
     }
 
     /**
+     *
+     * Returns the string with the first letter of each word capitalized,
+     * except for when the word is a name which shouldn't be capitalized.
+     *
+     * @return Stringy Object with $str capitalized
+     */
+    public function capitalizePersonName()
+    {
+        $stringy = $this->collapseWhitespace();
+        $stringy->str = $this->capitalizePersonNameByDelimiter($stringy->str, ' ');
+        $stringy->str = $this->capitalizePersonNameByDelimiter($stringy->str, '-');
+        return $stringy;
+    }
+
+    /**
+     * @param string $word
+     * @return string
+     */
+    private function capitalizeWord($word)
+    {
+        $encoding = $this->getEncoding();
+        $firstCharacter = mb_substr($word, 0, 1, $encoding);
+        $restOfWord = mb_substr($word, 1, null, $encoding);
+        $firstCharacterUppercased = mb_strtoupper($firstCharacter, $encoding);
+        return $firstCharacterUppercased . $restOfWord;
+    }
+    /**
+     * @param string $names
+     * @param string $delimiter
+     * @return string
+     */
+    private function capitalizePersonNameByDelimiter($names, $delimiter)
+    {
+        $names = explode($delimiter, $names);
+        $encoding = $this->getEncoding();
+
+        $specialCases = array(
+            'names' => array(
+                'ab',
+                'af',
+                'al',
+                'and',
+                'ap',
+                'bint',
+                'binte',
+                'da',
+                'de',
+                'del',
+                'den',
+                'der',
+                'di',
+                'dit',
+                'ibn',
+                'la',
+                'mac',
+                'nic',
+                'of',
+                'ter',
+                'the',
+                'und',
+                'van',
+                'von',
+                'y',
+                'zu'
+            ),
+            'prefixes' => array(
+                'al-',
+                "d'",
+                'ff',
+                "l'",
+                'mac',
+                'mc',
+                'nic'
+            )
+        );
+
+        foreach ($names as $key => $name) {
+            if (in_array($name, $specialCases['names'])) {
+                continue;
+            }
+            $continue = false;
+            if ($delimiter == '-') {
+                foreach ($specialCases['names'] as $beginning) {
+                    if (mb_strpos($name, $beginning, null, $encoding) === 0) {
+                        $continue = true;
+                    }
+                }
+            }
+            foreach ($specialCases['prefixes'] as $beginning) {
+                if (mb_strpos($name, $beginning, null, $encoding) === 0) {
+                    $continue = true;
+                }
+            }
+            if ($continue) {
+                continue;
+            }
+            $names[$key] = $this->capitalizeWord($name);
+        }
+        $names = implode($delimiter, $names);
+        return $names;
+    }
+
+    /**
      * Returns the replacements for the toAscii() method.
      *
      * @return array An array of replacements.

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -2422,4 +2422,62 @@ class StringyTestCase extends PHPUnit_Framework_TestCase
             array('>', '&gt;'),
         );
     }
+
+    /**
+     * @dataProvider capitalizePersonNameProvider()
+     */
+    public function testCapitalizePersonName($expected, $str, $encoding = null)
+    {
+        $stringy = S::create($str, $encoding);
+        $result = $stringy->capitalizePersonName();
+        $this->assertStringy($result);
+        $this->assertEquals($expected, $result);
+        $this->assertEquals($str, $stringy);
+    }
+
+    public function capitalizePersonNameProvider()
+    {
+        return array(
+            array('Marcus Aurelius', 'marcus aurelius'),
+            array('Torbjørn Færøvik', 'torbjørn færøvik'),
+            array('Jaap de Hoop Scheffer', 'jaap de hoop scheffer'),
+            array('K. Anders Ericsson', 'k. anders ericsson'),
+            array('Per-Einar', 'per-einar'),
+            array('Line Break', 'line
+             break'),
+            array('ab', 'ab'),
+            array('af', 'af'),
+            array('al', 'al'),
+            array('and', 'and'),
+            array('ap', 'ap'),
+            array('bint', 'bint'),
+            array('binte', 'binte'),
+            array('da', 'da'),
+            array('de', 'de'),
+            array('del', 'del'),
+            array('den', 'den'),
+            array('der', 'der'),
+            array('di', 'di'),
+            array('dit', 'dit'),
+            array('ibn', 'ibn'),
+            array('la', 'la'),
+            array('mac', 'mac'),
+            array('nic', 'nic'),
+            array('of', 'of'),
+            array('ter', 'ter'),
+            array('the', 'the'),
+            array('und', 'und'),
+            array('van', 'van'),
+            array('von', 'von'),
+            array('y', 'y'),
+            array('zu', 'zu'),
+            array('Bashar al-Assad', 'bashar al-assad'),
+            array("d'Name", "d'Name"),
+            array('ffName', 'ffName'),
+            array("l'Name", "l'Name"),
+            array('macDuck', 'macDuck'),
+            array('mcDuck', 'mcDuck'),
+            array('nickMick', 'nickMick')
+        );
+    }
 }


### PR DESCRIPTION
Hi @danielstjules,

Thanks for Stringy.

I added a method for capitalizing person names. Imagine that a user enters his name in lowercase, e.g. 'jaap de hoop scheffer', and that you'd like to capitalize it. Now, 'jaap', 'hoop' and 'scheffer' should be capitalized, but not 'de'. A naïve approach where every word is capitalized would result in wrong capitalization ('de' would be capitalized). `Stringy->capitalizePersonName()` takes care of that by checking the string to be capitalized against a list of special cases such as 'de'.

Can you please review this pull request? I'll be happy to fix any issues.

Some things to keep in mind for the review:
- I'm not very familiar with Stringy, so I may have made some less-than-ideal architectural choices, duplicated some code, etc.
- I'm inexperienced with character encoding.

Overall, I'm quite inexperienced as a developer, and I made this pull request partly as a learning experience. Therefore, I'd deeply appreciate feedback on my contribution.
