### PR TITLE
Fix safeTruncate to handle strings with no spaces.

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1098,7 +1098,9 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
         if (mb_strpos($stringy->str, ' ', $length - 1, $encoding) != $length) {
             // Find pos of the last occurrence of a space, get up to that
             $lastPos = \mb_strrpos($truncated, ' ', 0, $encoding);
-            $truncated = \mb_substr($truncated, 0, $lastPos, $encoding);
+            if ($lastPos !== false) {
+                $truncated = \mb_substr($truncated, 0, $lastPos, $encoding);
+            }
         }
 
         $stringy->str = $truncated . $substring;


### PR DESCRIPTION
Before this, calling safeTruncate with a string without spaces and a truncate length less than the string length would return an empty string.
