### PR TITLE
Fix exception typo

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1859,7 +1859,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
         if (isset($supported[$this->encoding])) {
             return true;
         } else {
-            throw new \RuntimeExpception('Stringy method requires the ' .
+            throw new \RuntimeException('Stringy method requires the ' .
                 'mbstring module for encodings other than ASCII and UTF-8');
         }
     }


### PR DESCRIPTION
I think it should be `\RuntimeException`. I haven't test it.