### PR TITLE
Fix #116: Update toAscii to accept a locale

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1428,11 +1428,16 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      *
      * @param  bool    $removeUnsupported Whether or not to remove the
      *                                    unsupported characters
+     * @param  string  $locale            Locale of the source string
      * @return static Object whose $str contains only ASCII characters
      */
-    public function toAscii($removeUnsupported = true)
+    public function toAscii($removeUnsupported = true, $locale = 'en')
     {
         $str = $this->str;
+
+        foreach ($this->localeSpecificCharsArray($locale) as $key => $value) {
+            $str = str_replace($value, $key, $str);
+        }
 
         foreach ($this->charsArray() as $key => $value) {
             $str = str_replace($value, $key, $str);
@@ -1686,7 +1691,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
                             'α', 'ά', 'ἀ', 'ἁ', 'ἂ', 'ἃ', 'ἄ', 'ἅ', 'ἆ', 'ἇ',
                             'ᾀ', 'ᾁ', 'ᾂ', 'ᾃ', 'ᾄ', 'ᾅ', 'ᾆ', 'ᾇ', 'ὰ', 'ά',
                             'ᾰ', 'ᾱ', 'ᾲ', 'ᾳ', 'ᾴ', 'ᾶ', 'ᾷ', 'а', 'أ', 'အ',
-                            'ာ', 'ါ', 'ǻ', 'ǎ', 'ª', 'ა', 'अ', 'ا', 'ａ'),
+                            'ာ', 'ါ', 'ǻ', 'ǎ', 'ª', 'ა', 'अ', 'ا', 'ａ', 'ä'),
             'b'    => array('б', 'β', 'Ъ', 'Ь', 'ب', 'ဗ', 'ბ', 'ｂ'),
             'c'    => array('ç', 'ć', 'č', 'ĉ', 'ċ', 'ｃ'),
             'd'    => array('ď', 'ð', 'đ', 'ƌ', 'ȡ', 'ɖ', 'ɗ', 'ᵭ', 'ᶁ', 'ᶑ',
@@ -1715,7 +1720,8 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'o'    => array('ó', 'ò', 'ỏ', 'õ', 'ọ', 'ô', 'ố', 'ồ', 'ổ', 'ỗ',
                             'ộ', 'ơ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ', 'ø', 'ō', 'ő',
                             'ŏ', 'ο', 'ὀ', 'ὁ', 'ὂ', 'ὃ', 'ὄ', 'ὅ', 'ὸ', 'ό',
-                            'о', 'و', 'θ', 'ို', 'ǒ', 'ǿ', 'º', 'ო', 'ओ', 'ｏ'),
+                            'о', 'و', 'θ', 'ို', 'ǒ', 'ǿ', 'º', 'ო', 'ओ', 'ｏ',
+                            'ö'),
             'p'    => array('п', 'π', 'ပ', 'პ', 'پ', 'ｐ'),
             'q'    => array('ყ', 'ｑ'),
             'r'    => array('ŕ', 'ř', 'ŗ', 'р', 'ρ', 'ر', 'რ', 'ｒ'),
@@ -1726,7 +1732,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'u'    => array('ú', 'ù', 'ủ', 'ũ', 'ụ', 'ư', 'ứ', 'ừ', 'ử', 'ữ',
                             'ự', 'û', 'ū', 'ů', 'ű', 'ŭ', 'ų', 'µ', 'у', 'ဉ',
                             'ု', 'ူ', 'ǔ', 'ǖ', 'ǘ', 'ǚ', 'ǜ', 'უ', 'उ', 'ｕ',
-                            'ў'),
+                            'ў', 'ü'),
             'v'    => array('в', 'ვ', 'ϐ', 'ｖ'),
             'w'    => array('ŵ', 'ω', 'ώ', 'ဝ', 'ွ', 'ｗ'),
             'x'    => array('χ', 'ξ', 'ｘ'),
@@ -1734,7 +1740,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
                             'ϋ', 'ύ', 'ΰ', 'ي', 'ယ', 'ｙ'),
             'z'    => array('ź', 'ž', 'ż', 'з', 'ζ', 'ز', 'ဇ', 'ზ', 'ｚ'),
             'aa'   => array('ع', 'आ', 'آ'),
-            'ae'   => array('ä', 'æ', 'ǽ'),
+            'ae'   => array('æ', 'ǽ'),
             'ai'   => array('ऐ'),
             'at'   => array('@'),
             'ch'   => array('ч', 'ჩ', 'ჭ', 'چ'),
@@ -1747,7 +1753,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'kh'   => array('х', 'خ', 'ხ'),
             'lj'   => array('љ'),
             'nj'   => array('њ'),
-            'oe'   => array('ö', 'œ', 'ؤ'),
+            'oe'   => array('œ', 'ؤ'),
             'oi'   => array('ऑ'),
             'oii'  => array('ऒ'),
             'ps'   => array('ψ'),
@@ -1757,7 +1763,6 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'sx'   => array('ŝ'),
             'th'   => array('þ', 'ϑ', 'ث', 'ذ', 'ظ'),
             'ts'   => array('ц', 'ც', 'წ'),
-            'ue'   => array('ü'),
             'uu'   => array('ऊ'),
             'ya'   => array('я'),
             'yu'   => array('ю'),
@@ -1767,7 +1772,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
                             'Ặ', 'Â', 'Ấ', 'Ầ', 'Ẩ', 'Ẫ', 'Ậ', 'Å', 'Ā', 'Ą',
                             'Α', 'Ά', 'Ἀ', 'Ἁ', 'Ἂ', 'Ἃ', 'Ἄ', 'Ἅ', 'Ἆ', 'Ἇ',
                             'ᾈ', 'ᾉ', 'ᾊ', 'ᾋ', 'ᾌ', 'ᾍ', 'ᾎ', 'ᾏ', 'Ᾰ', 'Ᾱ',
-                            'Ὰ', 'Ά', 'ᾼ', 'А', 'Ǻ', 'Ǎ', 'Ａ'),
+                            'Ὰ', 'Ά', 'ᾼ', 'А', 'Ǻ', 'Ǎ', 'Ａ', 'Ä'),
             'B'    => array('Б', 'Β', 'ब', 'Ｂ'),
             'C'    => array('Ç','Ć', 'Č', 'Ĉ', 'Ċ', 'Ｃ'),
             'D'    => array('Ď', 'Ð', 'Đ', 'Ɖ', 'Ɗ', 'Ƌ', 'ᴅ', 'ᴆ', 'Д', 'Δ',
@@ -1791,7 +1796,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'O'    => array('Ó', 'Ò', 'Ỏ', 'Õ', 'Ọ', 'Ô', 'Ố', 'Ồ', 'Ổ', 'Ỗ',
                             'Ộ', 'Ơ', 'Ớ', 'Ờ', 'Ở', 'Ỡ', 'Ợ', 'Ø', 'Ō', 'Ő',
                             'Ŏ', 'Ο', 'Ό', 'Ὀ', 'Ὁ', 'Ὂ', 'Ὃ', 'Ὄ', 'Ὅ', 'Ὸ',
-                            'Ό', 'О', 'Θ', 'Ө', 'Ǒ', 'Ǿ', 'Ｏ'),
+                            'Ό', 'О', 'Θ', 'Ө', 'Ǒ', 'Ǿ', 'Ｏ', 'Ö'),
             'P'    => array('П', 'Π', 'Ｐ'),
             'Q'    => array('Ｑ'),
             'R'    => array('Ř', 'Ŕ', 'Р', 'Ρ', 'Ŗ', 'Ｒ'),
@@ -1799,14 +1804,14 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'T'    => array('Ť', 'Ţ', 'Ŧ', 'Ț', 'Т', 'Τ', 'Ｔ'),
             'U'    => array('Ú', 'Ù', 'Ủ', 'Ũ', 'Ụ', 'Ư', 'Ứ', 'Ừ', 'Ử', 'Ữ',
                             'Ự', 'Û', 'Ū', 'Ů', 'Ű', 'Ŭ', 'Ų', 'У', 'Ǔ', 'Ǖ',
-                            'Ǘ', 'Ǚ', 'Ǜ', 'Ｕ', 'Ў'),
+                            'Ǘ', 'Ǚ', 'Ǜ', 'Ｕ', 'Ў', 'Ü'),
             'V'    => array('В', 'Ｖ'),
             'W'    => array('Ω', 'Ώ', 'Ŵ', 'Ｗ'),
             'X'    => array('Χ', 'Ξ', 'Ｘ'),
             'Y'    => array('Ý', 'Ỳ', 'Ỷ', 'Ỹ', 'Ỵ', 'Ÿ', 'Ῠ', 'Ῡ', 'Ὺ', 'Ύ',
                             'Ы', 'Й', 'Υ', 'Ϋ', 'Ŷ', 'Ｙ'),
             'Z'    => array('Ź', 'Ž', 'Ż', 'З', 'Ζ', 'Ｚ'),
-            'AE'   => array('Ä', 'Æ', 'Ǽ'),
+            'AE'   => array('Æ', 'Ǽ'),
             'CH'   => array('Ч'),
             'DJ'   => array('Ђ'),
             'DZ'   => array('Џ'),
@@ -1817,14 +1822,13 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
             'KH'   => array('Х'),
             'LJ'   => array('Љ'),
             'NJ'   => array('Њ'),
-            'OE'   => array('Ö', 'Œ'),
+            'OE'   => array('Œ'),
             'PS'   => array('Ψ'),
             'SH'   => array('Ш'),
             'SHCH' => array('Щ'),
             'SS'   => array('ẞ'),
             'TH'   => array('Þ'),
             'TS'   => array('Ц'),
-            'UE'   => array('Ü'),
             'YA'   => array('Я'),
             'YU'   => array('Ю'),
             'ZH'   => array('Ж'),
@@ -1835,6 +1839,42 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
                             "\xE2\x80\xAF", "\xE2\x81\x9F", "\xE3\x80\x80",
                             "\xEF\xBE\xA0"),
         );
+    }
+
+    /**
+     * Returns the locale-specific replacements for the toAscii() method.
+     *
+     * @param  string $locale Locale of the source string
+     * @return array  An array of replacements.
+     */
+    protected function localeSpecificCharsArray($locale = 'en')
+    {
+        $split = preg_split('/[-_]/', $locale);
+        $locale = $split[0];
+
+        static $charsArray = array();
+        if (isset($charsArray[$locale])) {
+            return $charsArray[$locale];
+        }
+
+        $localeSpecific = array(
+            'de' => array(
+                'ae' => array('ä'),
+                'oe' => array('ö'),
+                'ue' => array('ü'),
+                'AE' => array('Ä'),
+                'OE' => array('Ö'),
+                'UE' => array('Ü')
+            )
+        );
+
+        if (isset($localeSpecific[$locale])) {
+            $charsArray[$locale] = $localeSpecific[$locale];
+        } else {
+            $charsArray[$locale] = array();
+        }
+
+        return $charsArray[$locale];
     }
 
     /**

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -653,10 +653,11 @@ class StringyTestCase extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider toAsciiProvider()
      */
-    public function testToAscii($expected, $str, $removeUnsupported = true)
+    public function testToAscii($expected, $str, $removeUnsupported = true,
+                                $locale = 'en')
     {
         $stringy = S::create($str);
-        $result = $stringy->toAscii($removeUnsupported);
+        $result = $stringy->toAscii($removeUnsupported, $locale);
         $this->assertStringy($result);
         $this->assertEquals($expected, $result);
         $this->assertEquals($str, $stringy);
@@ -682,6 +683,9 @@ class StringyTestCase extends PHPUnit_Framework_TestCase
             array(' ', '　'), // ideographic space (U+3000)
             array('', '𐍉'), // some uncommon, unsupported character (U+10349)
             array('𐍉', '𐍉', false),
+            array('aouAOU', 'äöüÄÖÜ'),
+            array('aeoeueAEOEUE', 'äöüÄÖÜ', false, 'de'),
+            array('aeoeueAEOEUE', 'äöüÄÖÜ', false, 'de_DE')
         );
     }
 


### PR DESCRIPTION
**WIP**

https://github.com/danielstjules/Stringy/issues/116 brought up the issue that toAscii needs to be locale-aware when performing transliteration.

For example, Ö was added in https://github.com/danielstjules/Stringy/commit/2fe42b46a1d89dd829414f6c498c71d63e3b6db7 but a regression was later committed in https://github.com/danielstjules/Stringy/commit/ee4b89c2f8aef09d740f2dccd193fe3f8e64b33f This is because in german, Ö should map to OE, while in most other languages, it should map to O.

The regression (/breaking change) occurred in a minor release (2.2.0), but it's unclear if this PR would force a new major. Simply adding the locale parameter would indicate a minor bump. I've also been careful not to modify or remove the call to `charsArray` from `toAscii` since some users overwrite its implementation in their projects.