### PR TITLE
Implement JsonSerializable

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -7,10 +7,11 @@ use ArrayIterator;
 use Countable;
 use Exception;
 use InvalidArgumentException;
+use JsonSerializable;
 use IteratorAggregate;
 use OutOfBoundsException;
 
-class Stringy implements Countable, IteratorAggregate, ArrayAccess
+class Stringy implements Countable, IteratorAggregate, ArrayAccess, JsonSerializable
 {
     /**
      * An instance's string.
@@ -81,6 +82,15 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
     public function __toString()
     {
         return $this->str;
+    }
+
+    /**
+     * Returns value which can be serialized by json_encode().
+     *
+     * @return string The current value of the $str property
+     */
+    public function jsonSerialize() {
+        return (string) $this;
     }
 
     /**

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -56,6 +56,11 @@ class StringyTestCase extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, (string) new S($str));
     }
 
+    public function testToJson($expected, $str)
+    {
+        $this->assertEquals('"  foo bar  "', json_encode(new S('  foo bar  ')));
+    }
+
     public function toStringProvider()
     {
         return [


### PR DESCRIPTION
Currently, `json_encode(new S('hello'))` returns an empty object (`{}`). By implementing the JsonSerializable interface, we don't have to manually cast the Stringy instance to string before passing it to json_encode.