### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,6 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
-      env: polyfill='true'
-    - php: 5.4
-      env: polyfill='false'
-    - php: 5.5
-      env: polyfill='true'
-    - php: 5.5
-      env: polyfill='false'
     - php: 5.6
       env: polyfill='true'
     - php: 5.6
@@ -30,8 +22,11 @@ matrix:
       env: polyfill='true'
     - php: 7.1
       env: polyfill='false'
-
-install: travis_retry composer install --no-interaction --prefer-source
+      env: polyfill='false'
+    - php: 7.2
+      env: polyfill='true'
+    - php: 7.2
+      env: polyfill='false'
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "symfony/polyfill-mbstring": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^5.7 || ^6.5"
     },
     "support": {
         "issues": "https://github.com/danielstjules/Stringy/issues",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,9 +6,15 @@
          syntaxCheck="false">
     <testsuites>
         <testsuite name="Stringy">
-            <file>tests/StringyTest.php</file>
-            <file>tests/StaticStringyTest.php</file>
-            <file phpVersion="5.6.0">tests/CreateTest.php</file>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix="include.php">src</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use function Stringy\create as s;
+use PHPUnit\Framework\TestCase;
 
-class CreateTestCase extends PHPUnit_Framework_TestCase
+class CreateTestCase extends TestCase
 {
     public function testCreate()
     {

--- a/tests/StaticStringyTest.php
+++ b/tests/StaticStringyTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Stringy\StaticStringy as S;
+use PHPUnit\Framework\TestCase;
 
-class StaticStringyTestCase extends PHPUnit_Framework_TestCase
+class StaticStringyTestCase extends TestCase
 {
     /**
      * @expectedException BadMethodCallException
@@ -23,6 +24,13 @@ class StaticStringyTestCase extends PHPUnit_Framework_TestCase
         $result = S::toLowerCase('FOOBAR');
         $this->assertEquals('foobar', $result);
         $this->assertInternalType('string', $result);
+    }
+
+    public function testEmptyStringToBoolean()
+    {
+        $result = S::toBoolean('');
+        $this->assertFalse($result);
+        $this->assertInternalType('bool', $result);
     }
 
     public function testPartialArgsInvocation()

--- a/tests/StringyTest.php
+++ b/tests/StringyTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Stringy\Stringy as S;
+use PHPUnit\Framework\TestCase;
 
-class StringyTestCase extends PHPUnit_Framework_TestCase
+class StringyTestCase extends TestCase
 {
     /**
      * Asserts that a variable is of a Stringy instance.
@@ -847,6 +848,12 @@ class StringyTestCase extends PHPUnit_Framework_TestCase
             [false, 'FÒÔ bàřs', 'fòô bàř', true, 'UTF-8'],
             [false, 'fòô bàřs', 'fòô BÀŘ', true, 'UTF-8'],
         ];
+    }
+
+    public function testStartsWithAnyOnNullSubstring()
+    {
+        $stringy = S::create('foo bar', 'UTF-8');
+        $this->assertFalse($stringy->startsWithAny(null));
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Remove the `php-5.4` and `php-5.5` support because it's time to let the repo require `php-5.6` now.
- Set the multiple PHPUnit versions to support different PHP versions.
- Add the correct filter white list in `phpunit.xml` file.
- Add more tests.
- Using the class-based PHPUnit namespace to be compatible with stable PHPUnit version.