### PR TITLE
Fixed wrong character range in preg pattern in slugify function

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -1170,7 +1170,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
 
         $stringy->str = str_replace('@', $replacement, $stringy);
         $quotedReplacement = preg_quote($replacement);
-        $pattern = "/[^a-zA-Z\d\s-_$quotedReplacement]/u";
+        $pattern = "/[^a-zA-Z\d\s\-_$quotedReplacement]/u";
         $stringy->str = preg_replace($pattern, '', $stringy);
 
         return $stringy->toLowerCase()->delimit($replacement)


### PR DESCRIPTION
Fixed following warning:

> Warning: preg_replace(): Compilation failed: invalid range in character class at offset 12 {"exception":"[object] (ErrorException(code: 0): Warning: preg_replace(): Compilation failed: invalid range in character class at offset 12 at vendor/danielstjules/stringy/src/Stringy.php:1174)"} []