### PR TITLE
[PHP 8.1] Add #[\ReturnTypeWillChange]

### DIFF
--- a/src/Stringy.php
+++ b/src/Stringy.php
@@ -267,6 +267,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      *
      * @return int The number of characters in the string, given the encoding
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->length();
@@ -450,6 +451,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      *
      * @return \ArrayIterator An iterator for the characters in the string
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->chars());
@@ -847,6 +849,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      * @param  mixed   $offset The index to check
      * @return boolean Whether or not the index exists
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $length = $this->length();
@@ -870,6 +873,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      * @throws \OutOfBoundsException If the positive or negative offset does
      *                               not exist
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $offset = (int) $offset;
@@ -890,6 +894,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      * @param  mixed      $value  Value to set
      * @throws \Exception When called
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // Stringy is immutable, cannot directly set char
@@ -903,6 +908,7 @@ class Stringy implements Countable, IteratorAggregate, ArrayAccess
      * @param  mixed      $offset The index of the character
      * @throws \Exception When called
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // Don't allow directly modifying the string


### PR DESCRIPTION
without this, it can cause error : 

```bash
PHP Deprecated:  Return type of Stringy\Stringy::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 270
Deprecated: Return type of Stringy\Stringy::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 270
PHP Deprecated:  Return type of Stringy\Stringy::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 453
Deprecated: Return type of Stringy\Stringy::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 453
PHP Deprecated:  Return type of Stringy\Stringy::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 850
Deprecated: Return type of Stringy\Stringy::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 850
PHP Deprecated:  Return type of Stringy\Stringy::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 873
Deprecated: Return type of Stringy\Stringy::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 873
PHP Deprecated:  Return type of Stringy\Stringy::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 893
Deprecated: Return type of Stringy\Stringy::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 893
PHP Deprecated:  Return type of Stringy\Stringy::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 906
Deprecated: Return type of Stringy\Stringy::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/rector-src/rector-src/vendor/danielstjules/stringy/src/Stringy.php on line 906
```